### PR TITLE
Fix image processing when mediaType is ALLMEDIA

### DIFF
--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -766,9 +766,14 @@ private void processResultFromGallery(int destType, Intent intent) {
     String fileLocation = FileHelper.getRealPath(uri, this.cordova);
     Log.d(LOG_TAG, "File location is: " + fileLocation);
 
-    // If you ask for video or all media type you will automatically get back a file URI
+    String uriString = uri.toString();
+
+    // Get the path to the image. Makes loading so much easier.
+    String mimeType = FileHelper.getMimeType(uriString, this.cordova);
+
+    // If you selected a video you will automatically get back a file URI
     // and there will be no attempt to resize any returned data
-    if (this.mediaType != PICTURE) {
+    if (!("image/jpeg".equalsIgnoreCase(mimeType) || "image/png".equalsIgnoreCase(mimeType))) {
 
         resultObj.filename = fileLocation;
         resultObj.json_metadata = "{}";
@@ -835,11 +840,6 @@ private void processResultFromGallery(int destType, Intent intent) {
             this.callbackContext.success(jsonResult);
 
         } else {
-
-            String uriString = uri.toString();
-
-            // Get the path to the image. Makes loading so much easier.
-            String mimeType = FileHelper.getMimeType(uriString, this.cordova);
             // If we don't have a valid image, quit.
             if (!("image/jpeg".equalsIgnoreCase(mimeType) || "image/png".equalsIgnoreCase(mimeType))) {
                 Log.d(LOG_TAG, "I either have a null image path or bitmap");


### PR DESCRIPTION
Previously, image processing was only performed if mediaType was set to PICTURE.

Fixes the following side affects when ALLMEDIA is selected:
1. On Samsung devices, the selected image from gallery isn't properly rotated (set to the correct orientation)
2. Resizing on images is not done
3. Images selected from cloud isn't processed properly
4. `file://` isn't added to the image path