### PR TITLE
Fix image orientation on IOS when loading photo from Gallery

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -65,14 +65,14 @@
         
         <source-file src="src/android/xml/camera_provider_paths.xml" target-dir="res/xml" />
         
-        <framework src="com.android.support:support-v4:$ANDROID_SUPPORT_V4_VERSION" />
+        <framework src="androidx.core:core:$ANDROIDX_CORE_VERSION" />
         <framework src="com.google.code.gson:gson:2.8.5" />
 
         <js-module src="www/CameraPopoverHandle.js" name="CameraPopoverHandle">
             <clobbers target="CameraPopoverHandle" />
         </js-module>
 
-         <preference name="ANDROID_SUPPORT_V4_VERSION" default="28.+"/>
+         <preference name="ANDROIDX_CORE_VERSION" default="1.2.0"/>
       
      </platform>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -72,7 +72,7 @@
             <clobbers target="CameraPopoverHandle" />
         </js-module>
 
-         <preference name="ANDROID_SUPPORT_V4_VERSION" default="27.+"/>
+         <preference name="ANDROID_SUPPORT_V4_VERSION" default="28.+"/>
       
      </platform>
 

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -64,7 +64,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
 import android.provider.MediaStore;
-import android.support.v4.content.FileProvider;
+import androidx.core.content.FileProvider;
 import android.util.Base64;
 import android.util.Log;
 import android.content.pm.PackageManager;

--- a/src/android/FileProvider.java
+++ b/src/android/FileProvider.java
@@ -16,4 +16,4 @@
  */
 package org.apache.cordova.camera;
 
-public class FileProvider extends android.support.v4.content.FileProvider {}
+public class FileProvider extends androidx.core.content.FileProvider {}

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -511,6 +511,7 @@ static NSString* toBase64(NSData* data) {
                             NSMutableDictionary *TIFFDictionary = [[metadata objectForKey:(NSString*)kCGImagePropertyTIFFDictionary]mutableCopy];
                             if (TIFFDictionary) {
                                 [self.metadata setObject:TIFFDictionary forKey:(NSString*)kCGImagePropertyTIFFDictionary];
+                                [[self.metadata valueForKey:(NSString*)kCGImagePropertyTIFFDictionary] removeObjectForKey:(NSString*)kCGImagePropertyTIFFOrientation];
                             }
                             
                             


### PR DESCRIPTION
It seems the latest IOS fixes may have caused the images loaded from the gallery to have their orientation corrected on the file but the `Orientation` exif/tiff data is being kept after such transformation happened. This was causing images to be wrongly rendered.

This PR, remove the now made redundant `Orientation` exif tag when Image is loaded from the gallery.

Fixes #48.
